### PR TITLE
Bug fix uso de items

### DIFF
--- a/MMOTFG_Bot/MMOTFG_Bot/Inventory/InventorySystem.cs
+++ b/MMOTFG_Bot/MMOTFG_Bot/Inventory/InventorySystem.cs
@@ -95,6 +95,12 @@ namespace MMOTFG_Bot
             ObtainableItem item;
             if (StringToItem(itemString, out item))
             {
+                if (!item.UnderstandsCommand(command))
+                {
+                    await TelegramCommunicator.SendText(chatId, "Can't do that with that item");
+                    return;
+                }
+
                 //If the item isn't contained in the inventory, there is no point in continuing.
                 if (!InventoryRecords.Exists(x => x.InventoryItem.iD == item.iD))
                 {

--- a/MMOTFG_Bot/MMOTFG_Bot/Inventory/ObtainableItem.cs
+++ b/MMOTFG_Bot/MMOTFG_Bot/Inventory/ObtainableItem.cs
@@ -14,6 +14,18 @@ namespace MMOTFG_Bot
         public string name { get; set; }
         public int maxStackQuantity { get; set; }
 
+        public bool UnderstandsCommand(string command)
+        {
+            foreach (KeyValuePair<string, Action<long, string[]>> a in key_words)
+            {
+                if (a.Key == command)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         public bool ProcessCommand(string command, long chatId, string[] args = null)
         {
             foreach (KeyValuePair<string, Action<long, string[]>> a in key_words)


### PR DESCRIPTION
Cuando usabas un objeto pero le pasabas un comando que no debería reconocer (/use health_potion),
consumía el item pero no aplicaba el efecto.

Ahora si el objeto no entiende el comando te manda un mensaje diciendo que no puedes hacer eso con el objeto