### PR TITLE
El jugador pasa un turno al consumir un objeto + Ahora se reflejan cambios de stats fuera de batalla

### DIFF
--- a/MMOTFG_Bot/MMOTFG_Bot/Battle/BattleSystem.cs
+++ b/MMOTFG_Bot/MMOTFG_Bot/Battle/BattleSystem.cs
@@ -111,7 +111,7 @@ namespace MMOTFG_Bot
             useAttack(chatId, attack, player, enemy); 
         }
 
-        private static async void enemyAttack(long chatId)
+        public static async void enemyAttack(long chatId)
         {
             Attack attack = enemy.nextAttack();
 

--- a/MMOTFG_Bot/MMOTFG_Bot/Battle/BattleSystem.cs
+++ b/MMOTFG_Bot/MMOTFG_Bot/Battle/BattleSystem.cs
@@ -25,7 +25,7 @@ namespace MMOTFG_Bot
 
             update.Add(DbConstants.PLAYER_FIELD_BATTLE_ACTIVE, battleActive);
             update.Add(DbConstants.PLAYER_FIELD_BATTLE_INFO, player.getSerializable());
-            if (enemy == null) { 
+            if (!battleActive) { 
                 update.Add(DbConstants.PLAYER_FIELD_ENEMY, null); 
             }
             else update.Add(DbConstants.PLAYER_FIELD_ENEMY, enemy.getSerializable());

--- a/MMOTFG_Bot/MMOTFG_Bot/Battle/BattleSystem.cs
+++ b/MMOTFG_Bot/MMOTFG_Bot/Battle/BattleSystem.cs
@@ -181,6 +181,12 @@ namespace MMOTFG_Bot
             return bar;
         }
 
+        public static async Task changePlayerStats(long chatId, StatName stat, float amount)
+        {
+            player.changeStat(stat, amount);
+            await SavePlayerBattle(chatId);
+        }
+
         public static async void showStatus(long chatId, Battler b)
         {
             await LoadPlayerBattle(chatId);

--- a/MMOTFG_Bot/MMOTFG_Bot/Commands/cUseItem.cs
+++ b/MMOTFG_Bot/MMOTFG_Bot/Commands/cUseItem.cs
@@ -20,13 +20,13 @@ namespace MMOTFG_Bot.Commands
             };
         }
 
-        internal override void Execute(string command, long chatId, string[] args = null)
+        internal async override void Execute(string command, long chatId, string[] args = null)
         {
-            if(args.Length == 1) InventorySystem.ConsumeItem(chatId, args[0], 1, command, args);
+            if(args.Length == 1) await InventorySystem.ConsumeItem(chatId, args[0], 1, command, args);
             else
             {
-                if(args[1] == "all") InventorySystem.ConsumeItem(chatId, args[0], -1, command, args);
-                else InventorySystem.ConsumeItem(chatId, args[0], int.Parse(args[1]), command, args);
+                if(args[1] == "all") await InventorySystem.ConsumeItem(chatId, args[0], -1, command, args);
+                else await InventorySystem.ConsumeItem(chatId, args[0], int.Parse(args[1]), command, args);
             }
         }
 

--- a/MMOTFG_Bot/MMOTFG_Bot/Inventory/InventorySystem.cs
+++ b/MMOTFG_Bot/MMOTFG_Bot/Inventory/InventorySystem.cs
@@ -434,29 +434,40 @@ namespace MMOTFG_Bot
         /// </summary>
         public static async Task EquipGear(long chatId, EquipableItem item)
         {
+            //Load the player's inventory
             await LoadPlayerInventory(chatId);
+            //If the player is in the middle of a battle, it can't change it's equipment
             if (await BattleSystem.IsPlayerInBattle(chatId))
             {
                 await TelegramCommunicator.SendText(chatId, "Can't equip gear in battle");
             }
+            //If the player is not in a battle...
             else
             {
+                //Checks if the item is in the player's inventory. Parse from string
                 if (!InventoryRecords.Exists(x => x.InventoryItem.iD == item.iD))
                 {
                     await TelegramCommunicator.SendText(chatId, "Item " + item.name + " couldn't be equipped as it was not found in your inventory");
                 }
+                //If the item in in the player's inventory...
                 else
                 {
+                    //Check if the slot is currently being occupied
                     if (equipment[(int)item.gearSlot] != null)
                     {
+                        //If it's being occupied by the same item, just leave it as it is.
                         if (item.iD == equipment[(int)item.gearSlot].iD) await TelegramCommunicator.SendText(chatId, "You are already using that item");
+                        //If it's being occupied, swap the gear pieces.
                         else await SwapGear(chatId, item);
                     }
+                    //If the slot is free, occupy it with the new item.
                     else
                     {
+                        //Equip the new item
                         item.OnEquip(chatId);
 
                         string msg = "You have equipped " + item.name + "on your " + item.gearSlot.ToString().ToLower() + " slot.";
+                        //Apply the stat changes
                         if (item.statModifiers.Count > 0)
                         {
                             foreach (var stat in item.statModifiers)
@@ -471,12 +482,12 @@ namespace MMOTFG_Bot
                         equipment[(int)item.gearSlot] = item;
 
                         //Remove the item from the inventory
+                        //TO-DO: Kinda jank. Currently needed because consumeItem needs to load the currentBattle. If this wasn't added, ConsumeItem would override the stat changes from the item that was just equipped.
+                        await BattleSystem.SavePlayerBattle(chatId); 
                         await ConsumeItem(chatId, item.name, 1);
                     }
+                    await SavePlayerInventory(chatId);
                 }
-
-                await SavePlayerInventory(chatId);
-                await BattleSystem.SavePlayerBattle(chatId);
             }
         }
 

--- a/MMOTFG_Bot/MMOTFG_Bot/Inventory/Items/HealthPotion.cs
+++ b/MMOTFG_Bot/MMOTFG_Bot/Inventory/Items/HealthPotion.cs
@@ -15,13 +15,13 @@ namespace MMOTFG_Bot.Items
 
         private async void drinkPotion(long chatId, string[] args)
         {
-            BattleSystem.player.changeStat(HP, 500);
+            await BattleSystem.changePlayerStats(chatId, HP, 500);
             await TelegramCommunicator.SendText(chatId, "Gained 500HP.");
         }
 
         private async void eatPotion(long chatId, string[] args)
         {
-            BattleSystem.player.changeStat(HP, -2);
+            await BattleSystem.changePlayerStats(chatId, HP, -2);
             await TelegramCommunicator.SendText(chatId, "Why would you eat a potion you freak.\n Your health has been reduced by 2 points.");
         }
 

--- a/MMOTFG_Bot/MMOTFG_Bot/Inventory/Items/ManaPotion.cs
+++ b/MMOTFG_Bot/MMOTFG_Bot/Inventory/Items/ManaPotion.cs
@@ -15,13 +15,13 @@ namespace MMOTFG_Bot.Items
 
         private async void drinkPotion(long chatId, string[] args)
         {
-            BattleSystem.player.changeStat(MP, 5);
+            await BattleSystem.changePlayerStats(chatId, MP, 500);
             await TelegramCommunicator.SendText(chatId, "Gained 5MP.");
         }
 
         private async void eatPotion(long chatId, string[] args)
         {
-            BattleSystem.player.changeStat(MP, -2);
+            await BattleSystem.changePlayerStats(chatId, MP, -2);
             await TelegramCommunicator.SendText(chatId, "Why would you eat a potion you freak.\n Your MP has been reduced by 2.");
         }
 


### PR DESCRIPTION
Ahora si estás en batalla solo puedes usar 1 objeto en tu turno.
He cambiado el método de consumición de objetos para que, si se quiere usar solo 1, pase el turno.

Los cambios de stats no se reflejaban fuera de batlla porque no se guardaban en la base de datos. He tenido que modificar BattleSystem para adecuar este cambio. 
Cuando desde un item se desee cambiar los stats, ahora en vez de acceder de manera guarra al player de BattleSystem desde fuera, se accede a un método público de BattleSystem que modifica los stats internos del player y los refleja en la base de datos.